### PR TITLE
Splash Screen and Connection Status

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { ErrorBoundary } from 'src/app/FailScreen'
 import { Loading } from 'src/app/Loading'
+import { useSplashScreen } from 'src/app/splash'
 import { ModalProvider } from 'src/components/modal/modalContext'
 import { ModalTestScreen } from 'src/components/modal/ModalTestScreen'
 import { ExchangeConfirmationScreen } from 'src/features/exchange/ExchangeConfirmationScreen'
@@ -17,11 +18,10 @@ import { SendConfirmationScreen } from 'src/features/send/SendConfirmationScreen
 import { SendFormScreen } from 'src/features/send/SendFormScreen'
 import { DevTools } from 'src/features/settings/DevTools'
 import { ViewWalletScreen } from 'src/features/wallet/ViewWalletScreen'
-import { useSplashScreen } from 'src/utils/splash'
 
 export const App = () => {
-  const isSplash = useSplashScreen()
-  if (isSplash) return null //don't load the app until we're done with the splash screen
+  const showSplash = useSplashScreen()
+  if (showSplash) return null //don't load the app until we're done with the splash screen
 
   return (
     <ErrorBoundary>

--- a/src/app/splash.ts
+++ b/src/app/splash.ts
@@ -1,40 +1,54 @@
 import { useEffect, useState } from 'react'
 
-const defaultDelay = 2000
+const DEFAULT_DELAY = 1500
 
-export const getSplash = (loadingDelay?: number): [number, () => void] => {
-  const loader = document.querySelector('.loader')
-  const hideSplash = () => {
+//---
+//The work of managing and cleaning up the splash screen
+export const getSplash = (loadingDelay?: number): [number, () => NodeJS.Timeout | null] => {
+  const loader = document.getElementById('loader')
+
+  const hideSplash = (): NodeJS.Timeout | null => {
     if (loader) {
       const app = document.getElementById('app')
       app?.classList.add('fade-in')
       loader.classList.remove('.animate')
       loader.classList.add('loader--hide')
-      setTimeout(() => {
+      const fadeTimeout = setTimeout(() => {
         loader.parentElement?.removeChild(loader)
         app?.classList.remove('fade-in')
       }, 1000) //practice 'leave no trace'...
+      return fadeTimeout
     }
+    return null
   }
+
   const startStr = loader?.getAttribute('data-start')
   const startTime = startStr ? parseInt(startStr) : Date.now()
   const diff = Date.now() - startTime
-  loadingDelay = loadingDelay ?? defaultDelay
+  loadingDelay = loadingDelay ?? DEFAULT_DELAY
   const delay = diff > loadingDelay ? 0 : loadingDelay - diff
 
   return [delay, hideSplash]
 }
 
+//---
+//Hook to encapsulate and simplify the splash screen management
 export function useSplashScreen(loadingDelay?: number) {
   const [isSplash, setSplash] = useState(true)
 
   useEffect(() => {
     const [delay, hideSplash] = getSplash(loadingDelay)
+    let hideTimeout: NodeJS.Timeout | null = null
 
-    setTimeout(() => {
-      hideSplash()
+    const splashTimeout = setTimeout(() => {
+      hideTimeout = hideSplash()
       setSplash(false)
     }, delay)
+
+    return () => {
+      if (hideTimeout) clearTimeout(hideTimeout)
+      clearTimeout(splashTimeout)
+    }
   }, [])
 
   return isSplash

--- a/src/components/footer/ConnectionStatus.tsx
+++ b/src/components/footer/ConnectionStatus.tsx
@@ -1,14 +1,16 @@
 import { useSelector } from 'react-redux'
 import { RootState } from 'src/app/rootReducer'
 import { Box } from 'src/components/layout/Box'
+import { config } from 'src/config'
 import { Color } from 'src/styles/Color'
 import { Font } from 'src/styles/fonts'
+import { Styles } from 'src/styles/types'
 
 export const ConnectionStatus = () => {
   const { lastBlockNumber } = useSelector((state: RootState) => state.feed)
   //TODO: Get the Chain ID and the actuall connection status
   const status = 'You are connected to the Celo Mainnet network!'
-  const chain = '42220'
+  const chain = config.chainId
 
   return (
     <Box direction="column" align="center" styles={style.container}>
@@ -25,7 +27,7 @@ export const ConnectionStatus = () => {
   )
 }
 
-const style = {
+const style: Styles = {
   container: {
     paddingTop: '2em',
     '& p': {

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -74,11 +74,8 @@ const style: Stylesheet = {
     position: 'relative',
     cursor: 'pointer',
     '& svg': {
-      height: '3.5em',
-      width: '3.5em',
-      position: 'absolute',
-      top: '-1.7em',
-      left: '-.5em',
+      height: '1em',
+      width: '1em',
     },
   },
 }

--- a/src/components/icons/Connection.tsx
+++ b/src/components/icons/Connection.tsx
@@ -5,7 +5,8 @@ function _ConnectionIcon({ fill }: { fill: string }) {
     <svg
       enableBackground="new 0 0 1920 1260"
       version="1.1"
-      viewBox="0 0 1920 1260"
+      viewBox="394.00 534.00 655.67 482.90"
+      width="100"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/src/index.html
+++ b/src/index.html
@@ -59,7 +59,7 @@
       }
     </style>
     <style>
-      .loader{
+      #loader{
         position: absolute;
         top: 0;
         left: 0;
@@ -129,12 +129,12 @@
         animation: fadeIn 0.5s forwards;
       }
       @media only screen and (max-width: 768px) {
-        .loader{
+        #loader{
           margin-left: -11em;
         }
       }
       @media only screen and (max-width: 480px) {
-        .loader{
+        #loader{
           margin-left: -22em;
         }
       }
@@ -157,7 +157,7 @@
   <body>
     <div id="app"></div>
     
-    <div class="loader">
+    <div id="loader">
       <div class="loader-grid">
           <svg class="ellipse animate" width="205" height="240" viewBox="0 0 205 240" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M166.577 146.201C145.392 197.963 99.5149 228.176 64.1089 213.685C28.7029 199.193 17.175 145.485 38.3607 93.7229C59.5463 41.9611 105.423 11.7475 140.829 26.2389C176.235 40.7303 187.763 94.439 166.577 146.201Z" fill="#35D07F" fill-opacity="0.65"/>
@@ -177,7 +177,7 @@
     </div>
     
     <script>
-      document.querySelector('.loader').setAttribute('data-start', Date.now())
+      document.getElementById('loader').setAttribute('data-start', Date.now())
     </script>  
 
     <script src="bundle.js"></script>


### PR DESCRIPTION
For the splash screen, we could clean it up a bunch if we create small .js and .css files that don't get bundled.  We could also do the same with the .svgs so that we don't have so much code in the index.html.  We could also make a simpler animation, but I just went with the same one from the working modal.

For the Connection Status, we should re-visit the Connection svg because it has a 1920x1260 viewbox, and the icon is much smaller, and positioned in the middle or something.  I use a style to control the size, but then I have to futz with the positioning, and it is causing vertical scrollbars on the page... anyway, if we can trim out the extra whitespace in the svg, it won't require special handling.