### PR TITLE
Update wallet password error message

### DIFF
--- a/src/features/pincode/pincode.ts
+++ b/src/features/pincode/pincode.ts
@@ -43,7 +43,7 @@ export function validate(params: PincodeParams): ErrorState {
     if (isPin && value.length !== PIN_LENGTH) {
       errors = { ...errors, ...invalidInput('value', 'Pincode must be 6 digits') }
     } else if (isSecretTooSimple(value, type)) {
-      errors = { ...errors, ...invalidInput('value', 'Value is too simple') }
+      errors = { ...errors, ...invalidInput('value', 'Value is too simple or too complex') }
     }
     if (!valueConfirm) {
       errors = { ...errors, ...invalidInput('valueConfirm', 'Confirm value is required') }
@@ -59,7 +59,7 @@ export function validate(params: PincodeParams): ErrorState {
       if (isPin && newValue.length !== PIN_LENGTH) {
         errors = { ...errors, ...invalidInput('newValue', 'New Pincode must be 6 numbers') }
       } else if (isSecretTooSimple(newValue, type)) {
-        errors = { ...errors, ...invalidInput('newValue', 'New value is too simple') }
+        errors = { ...errors, ...invalidInput('newValue', 'New value is too simple or too complex') }
       } else if (newValue === value) {
         errors = { ...errors, ...invalidInput('newValue', 'New value is unchanged') }
       }


### PR DESCRIPTION
## Description 

When setting a wallet password, it's not clear if the password is too complex. This updates the error message so that it's a bit more clear. In the future the app should accept passwords longer than 32 characters with special characters.

## Test plan

1. Set up a new wallet
2. Enter in a password with less than 8 or more than 32 characters
3. Verify that the error message reads `New value is too simple or too complex`